### PR TITLE
購入ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import "reset";
+@import "./config/font";
 @import "top";
 @import "font-awesome-sprockets";
 @import "./font-awesome";
@@ -11,4 +12,5 @@
 @import "header";
 @import "banner";
 @import "footer";
+@import "purchase";
 @import "sell-btn";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
 @import "reset";
-@import "./config/font";
+@import "config/font";
 @import "top";
 @import "font-awesome-sprockets";
 @import "./font-awesome";

--- a/app/assets/stylesheets/config/font.scss
+++ b/app/assets/stylesheets/config/font.scss
@@ -1,0 +1,4 @@
+body {
+  font-family: arial, sans-serif;
+  font-size: 13px;
+}

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,0 +1,161 @@
+.purchase {
+  height: 900px;
+  width: 700px;
+  background-color: #ebf6f7;
+  margin: 50px auto;
+
+  a {
+    text-decoration: none;
+    color: steelblue;
+  }
+
+  &__title {
+    height: 100px;
+    line-height: 100px;
+
+    h2 {
+      letter-spacing: 1px;
+      font-weight: bold;
+      font-size: 18px;
+      text-align: center;
+    }
+  }
+
+  &__item {
+    border-top: solid 1px lightgray;
+    border-bottom: solid 1px lightgray;
+    height: 140px;
+
+    &__box {
+      display: flex;
+      height: 80px;
+      width: 350px;
+      margin: 30px auto;
+
+      &__image {
+        width: 80px;
+        margin-right: 20px;
+
+        img {
+          height: 100%;
+          width: 100%;
+        }
+      }
+      &__description {
+        letter-spacing: 1px;
+        width: 250px;
+
+        .item__title {
+          padding-bottom: 10px;
+        }
+        .item__price {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+
+  &__data {
+    height:630px;
+    width: 350px;
+    margin: 30px auto;
+
+    &__price {
+      display: flex;
+      justify-content: space-between;
+      border-bottom: solid 1px lightgray;
+      height: 100px;
+      line-height: 70px;
+
+      &__title {
+        font-size: 18px;
+      }
+      &__amount {
+        font-weight: bold;
+        font-size: 24px;
+      }
+    }
+    &__payment {
+      border-bottom: solid 1px lightgray;
+      height: 200px;
+      padding: 30px 0;
+
+      &__title {
+        display: flex;
+        justify-content: space-between;
+
+        .title__text {
+          font-size: 15px;
+        }
+      }
+      &__list {
+        margin-top: 10px;
+
+        .card__title {
+          margin-top: 5px;
+        }
+        .card__number {
+          margin-top: 5px;
+        }
+        .card__limit {
+          margin-top: 5px;
+        }
+        .card__type {
+          margin-top: 5px;
+        }
+      }
+    }
+    .purchase__data__shipping {
+      border-bottom: solid 1px lightgray;
+      height: 200px;
+      padding: 30px 0;
+
+      .purchase__data__shipping__title {
+        display: flex;
+        justify-content: space-between;
+
+        .title__text {
+          font-size: 15px;
+        }
+      }
+      .purchase__data__shipping__box {
+        margin-top: 10px;
+
+        .postcode {
+          margin-top: 5px;
+        }
+        .address {
+          margin-top: 5px;
+        }
+        .buyer {
+          margin-top: 5px;
+        }
+      }
+    }
+
+    .purchase__submit {
+      margin-top: 30px;
+      height: 100px;
+      text-align: center;
+
+      &__btn {
+        width: 350px;
+        height: 50px;
+        line-height: 50px;
+        background-color: turquoise;
+        cursor: pointer;
+        margin: 0 auto;
+        color: white;
+      }
+      &__none {
+        width: 350px;
+        height: 50px;
+        line-height: 50px;
+        background-color: gray;
+        cursor: not-allowed;
+        margin: 0 auto;
+        color: white;
+      }
+    }
+  }
+}

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -1,0 +1,64 @@
+= render "users/shared/header-logo"
+
+.purchase
+  .purchase__title
+    %h2 購入内容の確認
+
+  .purchase__item
+    .purchase__item__box
+      .purchase__item__box__image
+        = image_tag "/animal1.png"
+      .purchase__item__box__description
+        .item_title
+          商品タイトルが長くなった場合を試します
+        .item__price
+          金額（税込）送料込
+
+  %section.purchase__data
+    .purchase__data__price
+      .purchase__data__price__title
+        支払い金額
+      .purchase__data__price__amount
+        ¥10,000
+
+    .purchase__data__payment
+      .purchase__data__payment__title
+        .title__text
+          支払い方法
+        .card__change
+          = link_to "変更する", "#"
+        -# カード登録があればカード一覧、無ければ下記の一文とリンク表示、の分岐予定
+        .card__regist
+          = link_to "＋登録してください", "#"
+      .purchase__data__payment__list
+        -# PAY.JPの埋め込みの可能性があるため、仮置きとなります
+        .card__title
+          クレジットカード
+        .card__number
+          ****************
+        .card__limit
+          有効期限 07/20
+        .card__type
+          VISA
+
+    .purchase__data__shipping
+      .purchase__data__shipping__title
+        .title__text
+          配送先
+        .address__change
+          = link_to "変更する", "#"
+      .purchase__data__shipping__box
+        .postcode
+          〒123-4567
+        .address
+          東京都 渋谷区 道玄坂２丁目２３−１２ フォンティスビル７F
+        .buyer
+          購入者 氏名
+    .purchase__submit
+      -# 支払い方法の登録状況によって、ボタンの色が変わる予定
+      -# .purchase__submit__btn
+      -#   購入する
+      .purchase__submit__none
+        購入する
+
+= render "users/shared/footer-logo"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'mypages/index'
+  get "mypages/index"
   get "mypages/logout"
   get "mypages/card"
   devise_for :users, controllers: {
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   }
   resource :items, only: [:show]
   root "top#index"
-  get 'logout/index'
+  get "logout/index"
+  get "items/purchase"
+  # items/purchaseは画面を表示するための仮置きです
   resources :user, only:[:index, :edit, :destroy]
 end


### PR DESCRIPTION
# What
商品購入のビューのみとなります。
まずアプリケーション全体のフォントを基本的に揃えるためfont.scssの作成、設定。
application.scssにfontとpurchase（購入）を読み込むよう設定しました。
データベース設計に相談の余地があるため、コントローラー等は編集していません。
又、購入ページ内の分岐（支払い方法を登録しているか否かで、支払い方法選択箇所と購入するボタンの表示が変わります）
支払い方法や配送先の変更ボタンの遷移（現在URLは"#"）も全て仮置きとなります。

# Why
サーバーサイド実装前に、どのようなビューとなり、そこからの画面遷移や機能（支払い方法や配送先の複数登録）についてチームで共有するため。

# View
[![Image from Gyazo](https://i.gyazo.com/39674a336b39253f06fa896fca35f1a5.gif)](https://gyazo.com/39674a336b39253f06fa896fca35f1a5)