### PR TITLE
Db migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@
 |------|----|-------|
 |name|string|null: false|
 |text|text|null: false|
-|stock|int|null: false|
-|price|int|null: false|
+|stock|integer|null: false|
+|price|integer|null: false|
 |user_id|references|foreign_key: true|
 |category_id|references|foreign_key: true|
 |brand_id|references|foreign_key: true|
 |status_id|references|foreign_key: true|
+|saler_id|integer||
+|buyer_id|integer||
 
 ### Association
 - has_many :images

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@
 |------|----|-------|
 |name|string|null: false|
 |text|text|null: false|
-|stock|integer|null: false|
 |price|integer|null: false|
-|user_id|references|foreign_key: true|
 |category_id|references|foreign_key: true|
 |brand_id|references|foreign_key: true|
 |status_id|references|foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 |category_id|references|foreign_key: true|
 |brand_id|references|foreign_key: true|
 |status_id|references|foreign_key: true|
-|saler_id|integer||
+|seller_id|integer||
 |buyer_id|integer||
 
 ### Association

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,0 +1,3 @@
+class Brand < ApplicationRecord
+  has_many :items
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,6 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :brand
   belongs_to :status
-  belongs_to :saler, class_name: "User"
+  belongs_to :seller, class_name: "User"
   belongs_to :buyer, class_name: "User"
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,6 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :brand
   belongs_to :status
+  belongs_to :saler, class_name: "User"
+  belongs_to :buyer, class_name: "User"
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,6 @@
 class Item < ApplicationRecord
   has_many :images
   has_many :comments
-  belongs_to :user
   belongs_to :category
   belongs_to :brand
   belongs_to :status

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,3 @@
+class Status < ApplicationRecord
+  has_many :items
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,8 +32,8 @@ class User < ApplicationRecord
   has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
 
   #Userが現在売っている商品
-  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"
+  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Item"
 
   #Userが既に売った商品
-  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "saler_id", class_name: "Item"
+  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Item"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,13 @@ class User < ApplicationRecord
   validates :firstname_kana, presence: true, length: { maximum: 10 }, format: { with: VALID_FIRSTNAMEKANA_REGEX}
 
   validates :birthday, presence: true
+
+  #Userが買った商品
+  has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
+
+  #Userが現在売っている商品
+  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"
+
+  #Userが既に売った商品
+  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "saler_id", class_name: "Item"
 end

--- a/db/migrate/20200220031319_create_brands.rb
+++ b/db/migrate/20200220031319_create_brands.rb
@@ -1,0 +1,7 @@
+class CreateBrands < ActiveRecord::Migration[5.2]
+  def change
+    create_table :brands do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20200220031843_create_statuses.rb
+++ b/db/migrate/20200220031843_create_statuses.rb
@@ -1,0 +1,7 @@
+class CreateStatuses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :statuses do |t|
+      t.string :condition, null: false
+    end
+  end
+end

--- a/db/migrate/20200220032320_create_items.rb
+++ b/db/migrate/20200220032320_create_items.rb
@@ -3,10 +3,8 @@ class CreateItems < ActiveRecord::Migration[5.2]
     create_table :items do |t|
       t.string :name,         null: false
       t.text :text,           null: false
-      t.integer :stock,       null: false
       t.integer :price,       null: false
 
-      t.references :user,     foreign_key: true
       t.references :category, foreign_key: true
       t.references :brand,    foreign_key: true
       t.references :status,   foreign_key: true

--- a/db/migrate/20200220032320_create_items.rb
+++ b/db/migrate/20200220032320_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.references :brand,    foreign_key: true
       t.references :status,   foreign_key: true
 
-      t.integer :saler_id
+      t.integer :seller_id
       t.integer :buyer_id
 
       t.timestamps

--- a/db/migrate/20200220032320_create_items.rb
+++ b/db/migrate/20200220032320_create_items.rb
@@ -1,0 +1,20 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+      t.string :name,         null: false
+      t.text :text,           null: false
+      t.integer :stock,       null: false
+      t.integer :price,       null: false
+
+      t.references :user,     foreign_key: true
+      t.references :category, foreign_key: true
+      t.references :brand,    foreign_key: true
+      t.references :status,   foreign_key: true
+
+      t.integer :saler_id
+      t.integer :buyer_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_19_064831) do
+ActiveRecord::Schema.define(version: 2020_02_20_032320) do
+
+  create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+  end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -24,6 +28,29 @@ ActiveRecord::Schema.define(version: 2020_02_19_064831) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_credit_cards_on_user_id"
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "text", null: false
+    t.integer "stock", null: false
+    t.integer "price", null: false
+    t.bigint "user_id"
+    t.bigint "category_id"
+    t.bigint "brand_id"
+    t.bigint "status_id"
+    t.integer "saler_id"
+    t.integer "buyer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["brand_id"], name: "index_items_on_brand_id"
+    t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["status_id"], name: "index_items_on_status_id"
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "condition", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -45,4 +72,8 @@ ActiveRecord::Schema.define(version: 2020_02_19_064831) do
   end
 
   add_foreign_key "credit_cards", "users"
+  add_foreign_key "items", "brands"
+  add_foreign_key "items", "categories"
+  add_foreign_key "items", "statuses"
+  add_foreign_key "items", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2020_02_20_032320) do
     t.bigint "category_id"
     t.bigint "brand_id"
     t.bigint "status_id"
-    t.integer "saler_id"
+    t.integer "seller_id"
     t.integer "buyer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# What
新たにbrand, status, itemのテーブルを作成。
相談の上DB設計を変更し、販売者と購入者が分かりやすくなるよう、saler_idとbuyer_idを組み込み、itemとuserのモデルでアソシエーションの記述を行なっています。
又、上記によりitemsテーブルのuser_idとstockを削除しました。

# Why
元々のDB設計だと販売者と購入者の判別がつかず、データの区分けや読み取りが難しくなると判断したため。
又、user_idはsaler_idとbuyer_idとなり、2つのidを元にstock（在庫）の表示を行うため、カラムとして用意する必要がなくなったため。