### PR TITLE
Set capistrano

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  # before_action :basic_auth, if: :production?
+  before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
@@ -7,15 +7,16 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :lastname, :firstname, :lastname_kana, :firstname_kana, :birthday])
   end
 
-  # private
+  private
 
-  # def production?
-  #   Rails.env.production?
-  # end
+  # production環境に限りBasic認証を実装
+  def production?
+    Rails.env.production?
+  end
 
-  # def basic_auth
-  #   authenticate_or_request_with_http_basic do |username, password|
-  #     username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-  #   end
-  # end
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,6 +8,8 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 
 server "52.197.205.247", user: "ec2-user", roles: %w{app db web}
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 
 # set :rails_env, "production"
 # set :unicorn_rack_env, "production"


### PR DESCRIPTION
# What
Capistranoによる自動デプロイの設定、自動デプロイの成功を確認後、Basic認証の設定を行いました。

# Why
誤ってアクセスしたユーザーに誤解を生むことがないよう、又、悪意のあるアクセスを多少防ぐために、Basic認証で閲覧できるユーザーを制限するため。