### PR TITLE
トップ、マイページと出品機能の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,9 +4,10 @@ class ItemsController < ApplicationController
   before_action :set_parents
 
   def index
+    @items = Item.includes(:images).order('created_at DESC').limit(3)
     # 仮置きですが、ピックアップはレディース／メンズになっています
-    @pickupladies = Item.includes(:images).where(category: 1..180).order('created_at DESC').limit(3)
-    @pickupmens = Item.includes(:images).where(category: 181..310).order('created_at DESC').limit(3)
+    # @pickupladies = Item.includes(:images).where(category: 1..180).order('created_at DESC').limit(3)
+    # @pickupmens = Item.includes(:images).where(category: 181..310).order('created_at DESC').limit(3)
   end
 
   def new
@@ -27,11 +28,10 @@ class ItemsController < ApplicationController
     @category_grandchildren = Category.find("#{params[:child_id]}").children
   end
 
-
-
   def create
     @item = Item.new(item_params)
-    if @item.save
+    # binding.pry
+    if @item.save!
       redirect_to root_path, alert: "出品しました"
     else
       redirect_to new_item_path, alert: "必須項目を入力してください"
@@ -66,7 +66,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :text, :price, :category_id, :status_id, brand_attributes: [:id, :name], images_attributes: [:picture, :_destroy, :id])
+    params.require(:item).permit(:name, :text, :price, :category_id, :status_id, brand_attributes: [:id, :name], images_attributes: [:picture, :_destroy, :id]).merge(seller_id: current_user.id)
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,6 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    # binding.pry
     if @item.save!
       redirect_to root_path, alert: "出品しました"
     else

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,8 +1,14 @@
 class MypagesController < ApplicationController
+  before_action :set_parents
 
   def index
   end
 
   def logout
+  end
+
+  private
+  def set_parents
+    @category_parent = Category.where(ancestry: nil)
   end
 end

--- a/app/views/items/_pickup.html.haml
+++ b/app/views/items/_pickup.html.haml
@@ -1,17 +1,18 @@
 .box__lists
-  = link_to item_path(item.id), class: "list" do
-    %figure
-      = image_tag item.images[0].picture.url, class: 'list__img'
-    .list__body
-      .name
-        = item.name
-      .details
-        %ul
-          %li
-            = number_to_currency(item.price, locales: 'jp')
-          %li
-            %i.favorite-icon
-              = icon('fas', 'star')
-              0
-        %p
-          (税込)
+  - @items.each do |item|
+    = link_to item_path(item.id), class: "list" do
+      %figure
+        = image_tag item.images[0].picture.url, class: 'list__img'
+      .list__body
+        .name
+          = item.name
+        .details
+          %ul
+            %li
+              = number_to_currency(item.price, locales: 'jp')
+            %li
+              %i.favorite-icon
+                = icon('fas', 'star')
+                0
+          %p
+            (税込)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -104,6 +104,7 @@
             新規投稿商品
           = render partial: 'pickup', locals: {item: @item}
 
+    -# ピックアップカテゴリー実装時に以下のコメントアウト解除予定
     -# %span.pickup-category
     -#   .head
     -#     ピックアップカテゴリー／メンズ

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -97,21 +97,21 @@
             お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
     %span.pickup-category
       .head
-        ピックアップカテゴリー／レディース
+        ピックアップカテゴリー
       .box
         .box__head
           = link_to "#" do
             新規投稿商品
-          = render partial: 'pickup', collection: @pickupladies
+          = render partial: 'pickup', locals: {item: @item}
 
-    %span.pickup-category
-      .head
-        ピックアップカテゴリー／メンズ
-      .box
-        .box__head
-          = link_to "#" do
-            新規投稿商品
-          = render partial: 'pickup', collection: @pickupmens
+    -# %span.pickup-category
+    -#   .head
+    -#     ピックアップカテゴリー／メンズ
+    -#   .box
+    -#     .box__head
+    -#       = link_to "#" do
+    -#         新規投稿商品
+    -#       = render partial: 'pickup', collection: @pickupmens
 
   %aside.banner
     = render 'shared/banner'


### PR DESCRIPTION
# What
・トップページのピックアップカテゴリーにエラー、臨時で新規投稿のみに修正
・マイページ遷移時にカテゴリーが受け取れるよう記述追加
・出品時seller_idが付与されるよう記述追加
コメントアウト箇所はピックアップカテゴリー実装時のために残しています。

# Why
デプロイに向けて、エラーが発生しないよう修正したため。